### PR TITLE
allows for missing creator_user_name key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Databricks CI/CD
-[![PyPI Latest Release](https://img.shields.io/pypi/v/databricks-cicd.svg)](https://pypi.org/project/databricks-cicd/)
+
+[![PyPI Latest Release](https://img.shields.io/pypi/v/tactivos-databricks-cicd.svg)](https://pypi.org/project/tactivis-databricks-cicd/)
+
+### Forked from Manol Manolov's original databricks-cicd repo to use with tactivos/data-databricks repo
 
 This is a tool for building CI/CD pipelines for Databricks. It is a python package that
 works in conjunction with a custom GIT repository (or a simple file structure) to validate 
@@ -11,7 +14,7 @@ and deploy content to databricks. Currently, it can handle the following content
 * **DBFS** - an arbitrary collection of files that may be deployed on a Databricks workspace
 
 # Installation
-`pip install databricks-cicd`
+`pip install tactivos-databricks-cicd`
 
 # Requirements
 To use this tool, you need a source directory structure (preferably as a private GIT repository) 

--- a/databricks_cicd/utils/helpers.py
+++ b/databricks_cicd/utils/helpers.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Original work edited by Kevin Gould from Mural on 2023-07-17
+
 import logging
 import base64
 import json

--- a/databricks_cicd/utils/helpers.py
+++ b/databricks_cicd/utils/helpers.py
@@ -305,16 +305,19 @@ class JobsHelper(DeployHelperBase):
                 Endpoints.jobs_list, body={}, query=f"expand_tasks=true&limit={batch_size}&offset={offset}").text)
             jobs.extend([
                 i for i in jobs_batch.get('jobs', [])
-                if (i['creator_user_name'] == self._c.conf.deploying_service_name
-                    or i['creator_user_name'] == self._c.conf.deploying_user_name)
-                   and i['settings']['name'].startswith(self._c.conf.name_prefix)])
+                if ((i.get('creator_user_name') == self._c.conf.deploying_service_name
+                     or i.get('creator_user_name') == self._c.conf.deploying_user_name)
+                    and i['settings']['name'].startswith(self._c.conf.name_prefix))
+            ])
             result_count = len(jobs_batch.get('jobs', []))
             offset += batch_size
 
-        return {self.common_path(i['settings']['name']): Item(path=i['job_id'],
-                                                              kind='job',
-                                                              content=i['settings'])
-                for i in jobs}
+        return {
+            self.common_path(i['settings']['name']): Item(path=i['job_id'],
+                                                          kind='job',
+                                                          content=i['settings'])
+            for i in jobs
+        }
 
     def _ls_local(self):
         self.local_items = Local.files_ls(

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import databricks_cicd
 
 
 setup(
-    name='databricks-cicd',
+    name='tactivos-databricks-cicd',
     version=databricks_cicd.__version__,
     packages=find_packages(exclude=['tests', 'tests.*']),
     package_data={'': ['*.ini']},
@@ -29,11 +29,11 @@ setup(
         cicd=databricks_cicd.cli:cli
     ''',
     zip_safe=False,
-    author='Manol Manolov',
-    author_email='man40dev@gmail.com',
-    url='https://github.com/man40/databricks-cicd',
+    author='Manol Manolov - Minor changes from Kevin Gould (Mural)',
+    author_email='',
+    url='https://github.com/tactivos/databricks-cicd',
     project_urls={
-        "Source": "https://github.com/man40/databricks-cicd",
+        "Source": "https://github.com/tactivos/databricks-cicd",
     },
     description='CICD tool for testing and deploying to Databricks',
     long_description=io.open('README.md', encoding='utf-8').read(),


### PR DESCRIPTION
Deployment currently failing when "creator_user_name" is missing (Line 308)
Change wraps this i["creator_user_name"] in a get function, which will be None when it doesn't exist, allowing the following comparison to complete.